### PR TITLE
Prevent acd from trying to use non-existing pyacd methods when trying to authenticate when a client is still running.

### DIFF
--- a/acd
+++ b/acd
@@ -71,7 +71,7 @@ class ACDFS(fuse.Fuse):
                 self.session = pyacd.login(session=session)
                 self.session.__dict__['agreed_with_terms']=True
                 self.session.username = self.email
-            if not self.session.is_valid() or not self.session.is_logined():
+            if not self.session.is_logged_in():
                 raise ValueError
         except (IOError, ValueError, pyacd.exception.PyAmazonCloudDriveError):
             print "Cached session failed; trying auth login"


### PR DESCRIPTION
pyacd.Session.is_logined is renamed to is_logged_in(), and pyacd.Session.is_valid() is removed, thus unnecessary. The try block will raise an exception when trying to assign values to ACDFS.session is None. If that happens, we don't have to check if the session exists at all.