### PR TITLE
Add local pyacd to path, regardless of working directory

### DIFF
--- a/acd
+++ b/acd
@@ -15,11 +15,13 @@ import os.path
 import pickle
 import tempfile
 
+_THIS_DIR = os.path.dirname(os.path.realpath(__file__))
+
 try:
     import pyacd
 except ImportError:
     from sys import path
-    path.append('pyacd')
+    path.append(os.path.join(_THIS_DIR, 'pyacd'))
     import pyacd
 
 fuse.fuse_python_api = (0, 2)


### PR DESCRIPTION
This sets the path correctly, even if used or symlinked from a different directory
