### PR TITLE
Added -o tempdir for setting the directory where to store temporary files

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -83,6 +83,7 @@ Mount Options
 - `email`: your Amazon Cloud Drive login email
 - `password`: your Amazon Cloud Drive login password
 - `cachefree`: the percentage of free space to maintain on the filecache's file system; *10* by default
+- `tempdir`: the directory where to place temporary files (and sessionstore) instead of /tmp/acd/acd_fuse
 - **NOTE**: All of the (standard fuse mount options)[http://manpages.ubuntu.com/manpages/precise/man8/mount.fuse.8.html#contenttoc3] should work as well, including `allow_other` and `umask`.
 
 License

--- a/acd
+++ b/acd
@@ -55,17 +55,20 @@ class ACDFS(fuse.Fuse):
         '''
         fuse.Fuse.__init__(self, *args, **kw)
         self.api = pyacd.api
-        self.tempdir = os.path.join(tempfile.gettempdir(), myname)
-        if not os.path.exists(self.tempdir): os.mkdir(self.tempdir)
-        self.sessionfile = os.path.join(self.tempdir, "sessionfile")
 
         # setup logging
         self.log = logging.getLogger(myname)
+
+    def main(self):
+        if not self.tempdir:
+            self.tempdir = os.path.join(tempfile.gettempdir(), myname)
+        if not os.path.exists(self.tempdir): os.mkdir(self.tempdir)
+        self.sessionfile = os.path.join(self.tempdir, "sessionfile")
+
         hdlr = logging.FileHandler(os.path.join(self.tempdir, 'debug.log'))
         self.log.addHandler(hdlr)
         self.log.setLevel(logging.DEBUG)
 
-    def main(self):
         try:
             print "Trying to login from cached sessionfile %s" % self.sessionfile
             with open(self.sessionfile, "rb") as sessfile:
@@ -464,6 +467,8 @@ if __name__ == '__main__':
                          help="PASSWORD password for Amazon Cloud Drive")
     fs.parser.add_option(mountopt="cachefree",
                          help="What percentage of the filecache drive we must keep free (defaults to 10%)")
+    fs.parser.add_option(mountopt="tempdir", metavar="TEMPDIR",
+                         help="TEMPDIR directory to use for temporary files")
 
     fs.parse(values=fs, errex=1)
 


### PR DESCRIPTION
The temporary directory can get quite large, and as I use tmpfs that space is out from my memory. Additionally, it can be beneficial to to cache that information over reboots as well.

Moves the initialization of tempdir and sessionfile from init to main.
